### PR TITLE
Safariでビデオコントロールが表示されない問題のワークアラウンド

### DIFF
--- a/app/javascript/controllers/autoimport_controller.js
+++ b/app/javascript/controllers/autoimport_controller.js
@@ -1,0 +1,22 @@
+//
+// This is a workaround for the problem that video controlls are not shown
+//   -> https://discuss.hotwired.dev/t/video-tags-loaded-via-turbo-drive/2746
+//
+
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="autoimport"
+export default class extends Controller {
+  initialize() {
+    let v = this.element.content.querySelector("video")
+    let src = v.getAttribute("src")
+    this.element.replaceWith(this.videoTagWithSrc(src));
+  }
+
+  videoTagWithSrc(src) {
+    let nv = document.createElement("video")
+    nv.setAttribute("controls", "controlls")
+    nv.setAttribute("src", src)
+    return nv
+  }
+}

--- a/app/views/archives/show.html.erb
+++ b/app/views/archives/show.html.erb
@@ -5,7 +5,9 @@
   
   <article class="article">
     <% if @archive.video.attached? %>
-      <%= video_tag(url_for(@archive.video), controls: true) %>
+      <template data-controller="autoimport">
+        <%= video_tag(url_for(@archive.video), controls: true) %>
+      </template>
     <% else %>
       <p>no video</p>
     <% end %>


### PR DESCRIPTION
https://discuss.hotwired.dev/t/video-tags-loaded-via-turbo-drive/2746
によるとWebKit側の問題らしい。
上記の投稿を参考にワークアラウンドを実装した。
投稿されているコードそのままだと今度はFirefoxでvideoタグが表示されなくなったので、createElementでvideo要素をつくりなおしてからreplaceElementしている。