### PR TITLE
fix: YouTubeの音声形式の変更に追従する

### DIFF
--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -132,7 +132,7 @@ class Archive < ApplicationRecord
     Dir.mktmpdir do |dir|
       filename = File.join(dir, 'download.mp4')
       log_filename = File.join(dir, 'download.log')
-      command = 'yt-dlp --newline -f "bestvideo[ext=mp4]+bestaudio[ext=aac]/best[ext=mp4]" -o "%s" "%s"' % [filename, self.original_url]
+      command = 'yt-dlp --newline -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]" -o "%s" "%s"' % [filename, self.original_url]
       success = nil
       Open3.popen2e(command) do |stdin, stdoe, wait_thr|
         log = File.open(log_filename, 'w')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- 動画ダウンロードの音声フォーマットをm4aファイルとの互換性を向上させるために更新しました。

- **バグ修正**
	- 正しい音声ストリームフォーマットを確保するために、動画更新のコマンド文字列を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->