### PR TITLE
vcodecを指定するようにした

### DIFF
--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -132,7 +132,7 @@ class Archive < ApplicationRecord
     Dir.mktmpdir do |dir|
       filename = File.join(dir, 'download.mp4')
       log_filename = File.join(dir, 'download.log')
-      command = 'yt-dlp --newline -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]" -o "%s" "%s"' % [filename, self.original_url]
+      command = 'yt-dlp --newline -f "bestvideo[vcodec*=avc1]+bestaudio[ext=m4a]/best[vcodec=avc1]" -o "%s" "%s"' % [filename, self.original_url]
       success = nil
       Open3.popen2e(command) do |stdin, stdoe, wait_thr|
         log = File.open(log_filename, 'w')


### PR DESCRIPTION
### 概要

- yt-dlp のフォーマット指定で拡張子で指定するとVP9の動画がダウンロードされることがあるので、vcodecで指定するようにした

### レビュー方法

- config/environments/development.rb の`Rails.application.configure do ~ end` ブロックの中に以下の内容を追加する
  ```rb
  config.hosts << "localhost"
  config.hosts << "yourmachinename.local"
  ```
  - yourmachinename.local はYTDLORを実行中するマシンの、mDNSで解決可能なホスト名
- YTDLORを起動する
  ```sh
  ./docker_compose up --build
  ```
- iOSデバイスから http://yourmachinename.local:3000 にアクセスする
- ダウンロードした動画がiOSデバイスで再生できるかどうかを確認する